### PR TITLE
Add nokogiri dependency

### DIFF
--- a/dji.gemspec
+++ b/dji.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'thor', '>= 0.18.1', '< 2.0'
+  spec.add_dependency 'nokogiri'
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The gem currently doesn't declare its dependency on nokogiri. This PR adds it to the gemspec.
